### PR TITLE
Add Safety comment line and Copy/Clone on Allocation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ unsafe impl Sync for Allocator {}
 /// use `Allocator::get_allocation_info`.
 ///
 /// Some kinds allocations can be in lost state.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Allocation(ffi::VmaAllocation);
 unsafe impl Send for Allocation {}
 unsafe impl Sync for Allocation {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,9 @@ unsafe impl Sync for Allocation {}
 
 impl Allocator {
     /// Construct a new `Allocator` using the provided options.
-    /// Safety: [`AllocatorCreateInfo::instance`], [`AllocatorCreateInfo::device`] and
+    ///
+    /// # Safety
+    /// [`AllocatorCreateInfo::instance`], [`AllocatorCreateInfo::device`] and
     /// [`AllocatorCreateInfo::physical_device`] must be valid throughout the lifetime of the allocator.
     pub unsafe fn new(create_info: AllocatorCreateInfo) -> VkResult<Self> {
         unsafe extern "system" fn get_instance_proc_addr_stub(


### PR DESCRIPTION
Thanks for the great Fork of vk-mem-rs !

Two small but useful changes had been made on the vk-mem-rs crate.
The Clone and Copy on Allocation would save so much time and make it more usable.
The second change was just a "# Safety" line missing in the comment, always a good thing to have.